### PR TITLE
Fix login_field='both' — allow login via email or username

### DIFF
--- a/src/Http/Controllers/LoginController.php
+++ b/src/Http/Controllers/LoginController.php
@@ -94,6 +94,15 @@ class LoginController extends Controller
         if (config('tyro-login.captcha.enabled_login', false)) {
             $rules['captcha_answer'] = ['required', 'numeric'];
         }
+
+
+        if ($loginField === 'both') {
+            $loginValue = $request->input('both');
+            $field = filter_var($loginValue, FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
+            $request->merge([$field => $loginValue]);
+            $rules[$field] = $rules['login'];
+            unset($rules['login']);
+        }
         
         $credentials = $request->validate($rules);
 


### PR DESCRIPTION
### Problem
When `login_field` is set to "both", login fails with a SQL error because
the input field was always named 'login', which doesn’t match the database column.

### Solution
- Detect whether the input is an email or username using `filter_var`.
- Merge the correct field into the request (`email` or `username`).

This allows users to log in with either email or username when `login_field` is "both".

