### PR TITLE
Fix broken GitHub Pages links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-<a href="https://hasinhayder.github.io/tyro/tyro-login/">Website</a> |
-<a href="https://hasinhayder.github.io/tyro/tyro-login/doc.html">Documentation</a> |
+<a href="https://hasinhayder.github.io/tyro-login/">Website</a> |
+<a href="https://hasinhayder.github.io/tyro-login/doc.html">Documentation</a> |
 <a href="https://github.com/hasinhayder/tyro-login">GitHub</a>
 </p>
 


### PR DESCRIPTION
The **Website** and **Documentation** links in the README header pointed to https://hasinhayder.github.io/tyro/tyro-login/... which returns **404**. The live project site lives at https://hasinhayder.github.io/tyro-login/... (no extra `/tyro/` path segment).

### Audit of all `github.io` references in the repo

| File:Line | URL | Status |
| --- | --- | --- |
| `README.md:10` (Website) | `https://hasinhayder.github.io/tyro/tyro-login/` | **404** → fixed |
| `README.md:11` (Documentation) | `https://hasinhayder.github.io/tyro/tyro-login/doc.html` | **404** → fixed |
| `src/Console/Commands/DocCommand.php:21` | `https://hasinhayder.github.io/tyro-login/doc.html` | 200 (unchanged) |
| `src/Console/Commands/VersionCommand.php:35` | `https://hasinhayder.github.io/tyro-login/doc.html` | 200 (unchanged) |

The two code paths were already using the correct URL — only the README was wrong.

### Diff

```diff
-<a href="https://hasinhayder.github.io/tyro/tyro-login/">Website</a> |
-<a href="https://hasinhayder.github.io/tyro/tyro-login/doc.html">Documentation</a> |
+<a href="https://hasinhayder.github.io/tyro-login/">Website</a> |
+<a href="https://hasinhayder.github.io/tyro-login/doc.html">Documentation</a> |
```

### Verification

```bash
$ curl -s -o /dev/null -w "%{http_code}\n" https://hasinhayder.github.io/tyro-login/
200
$ curl -s -o /dev/null -w "%{http_code}\n" https://hasinhayder.github.io/tyro-login/doc.html
200
```